### PR TITLE
Change try_now xpath in Document sever

### DIFF
--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/document_server_api.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/document_server_api.rb
@@ -25,7 +25,7 @@ module TestingApiOnlyfficeCom
     link(:php, xpath: '//*[contains(@href, "PHP")]')
     link(:ruby, xpath: '//*[contains(@href, "Ruby")]')
 
-    link(:try_now, xpath: '//*[contains(@href, "editors/try")]')
+    link(:try_now, xpath: '//a[contains(@href, "editors/try")]')
     link(:try_now_docx_editor, xpath: '//*[contains(@href, "editors/editor?method=docxEditor")]')
 
     link(:integration_examples, xpath: '//*[contains(@href, "editors/demopreview")]')


### PR DESCRIPTION
Now xpath ```//*[contains(@href, "editors/try")]```, shows 2 matches
As was added link ```<link rel="canonical" href="http://api.teamlab.info/editors/try">``` to header
![Снимок экрана 2019-08-28 в 15 13 04](https://user-images.githubusercontent.com/40513035/63926739-05368200-ca55-11e9-946a-4101e99b5291.png)

