### PR TITLE
Delete Extra link in check_download_links method

### DIFF
--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_integrating.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/document_builder_api/document_builder_integrating.rb
@@ -36,7 +36,6 @@ module TestingApiOnlyfficeCom
     end
 
     def check_download_links
-      open_integrating_document_builder
       checked = {}
       DOC_BUILDER_EXAMPLES.each do |ex|
         link = send("#{ex}_element")


### PR DESCRIPTION
In test
```
it '[API][DocumentBuilder] Integrating Document Builder download links shown and alive' do
      integraing_page = @introduction_page.open_integrating_document_builder
      result, failed = integraing_page.download_links_ok?
      expect(result).to be_truthy, "Page #{@instance.webdriver.driver.current_url}\n\nBad mojo with document builder links:\n #{failed}"
    end
```
method ```open_integrating_document_builder```  has already been called earlyer in test 