### PR TITLE
Edit xpath for checking if Example and Example response contain something

### DIFF
--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/community_server_api/community_server_method_page.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/community_server_api/community_server_method_page.rb
@@ -12,7 +12,7 @@ module TestingApiOnlyfficeCom
       @params_exist ||= !@page.xpath('//div[@id="methodParams"]').empty?
       @example_exist ||= !@page.xpath('//div[@id="methodExample"]/pre').empty?
       @return_exist ||= !@page.xpath('//div[@id="methodReturns"]/p/text()').empty?
-      @document_exist ||= !@page.xpath('//div[@id="methodResponse"]/pre[1]').empty?
+      @document_exist ||= !@page.xpath('//div[@id="methodResponse"]/pre').empty?
     end
   end
 end

--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/community_server_api/community_server_method_page.rb
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/community_server_api/community_server_method_page.rb
@@ -10,9 +10,9 @@ module TestingApiOnlyfficeCom
       @link = "#{Config.new.server}/portals/method/#{ClassNameHelper.cleanup_name(current_module)}/#{ClassNameHelper.cleanup_name(method)}"
       @page = Nokogiri::HTML(URI.parse(@link).open)
       @params_exist ||= !@page.xpath('//div[@id="methodParams"]').empty?
-      @example_exist ||= !@page.xpath('//div[@id="methodExample"]').empty?
+      @example_exist ||= !@page.xpath('//div[@id="methodExample"]/pre').empty?
       @return_exist ||= !@page.xpath('//div[@id="methodReturns"]/p/text()').empty?
-      @document_exist ||= !@page.xpath('//div[@id="methodResponse"]').empty?
+      @document_exist ||= !@page.xpath('//div[@id="methodResponse"]/pre[1]').empty?
     end
   end
 end


### PR DESCRIPTION
If ```methodResponse``` isn't filled, text in div element isn't empty, so ```!@page.xpath('//div[@id="methodResponse"]').empty?``` will never be false
![PE empty](https://user-images.githubusercontent.com/40513035/64540470-f5f2e680-d328-11e9-8e8b-41e7aff738ab.png)
and when it's filled it contains another tags, one of them is ```pre```
![PR](https://user-images.githubusercontent.com/40513035/64540712-45d1ad80-d329-11e9-81bd-c21ad34a4889.png)

the same is for ```methodExample```

continue of #51 
