### PR TITLE
Remove `page-object` as dependency

### DIFF
--- a/gems.locked
+++ b/gems.locked
@@ -143,10 +143,9 @@ DEPENDENCIES
   onlyoffice_tcm_helper!
   onlyoffice_webdriver_wrapper!
   ooxml_parser!
-  page-object
   palladium!
   rspec
   rubocop
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/gems.rb
+++ b/gems.rb
@@ -9,7 +9,6 @@ gem 'onlyoffice_file_helper'
 gem 'onlyoffice_tcm_helper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_tcm_helper'
 gem 'onlyoffice_webdriver_wrapper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_webdriver_wrapper'
 gem 'ooxml_parser', git: 'https://github.com/ONLYOFFICE/ooxml_parser'
-gem 'page-object'
 gem 'palladium', git: 'https://github.com/flaminestone/palladium.git'
 gem 'rspec'
 gem 'rubocop', require: false


### PR DESCRIPTION
This gem is already required by
`onlyoffice_webdriver_wrapper`
No need to require it several times