### PR TITLE
Remove CommunityServer method `mail/messages/save`

### DIFF
--- a/lib/testing_api_onlyoffice_com/test_instance/main_page/community_server_api/document_entries.json
+++ b/lib/testing_api_onlyoffice_com/test_instance/main_page/community_server_api/document_entries.json
@@ -586,7 +586,6 @@
       "PUT/api/2.0/mail/messages/move",
       "PUT/api/2.0/mail/messages/remove",
       "PUT/api/2.0/mail/messages/restore",
-      "PUT/api/2.0/mail/messages/save",
       "PUT/api/2.0/mail/messages/send",
       "PUT/api/2.0/mail/messages/mark"
     ],

--- a/spec/failed_community_server_tests
+++ b/spec/failed_community_server_tests
@@ -299,7 +299,6 @@
 'mail/PUT/api/2.0/mail/messages/remove/Resulting document'
 'mail/PUT/api/2.0/mail/messages/restore/Resulting document'
 'mail/GET/api/2.0/mail/settings/conversationsEnabled/Resulting document'
-'mail/PUT/api/2.0/mail/messages/save/Resulting document'
 'mail/PUT/api/2.0/mail/messages/send/Resulting document'
 'mail/PUT/api/2.0/mail/settings/goNextAfterMoveEnabled/Resulting document'
 'mail/PUT/api/2.0/mail/messages/mark/Resulting document'


### PR DESCRIPTION
Current version is:
https://github.com/ONLYOFFICE/api.onlyoffice.com/commit/1bd3c2a23619e438cbd443dc745a8963bcc81652

Changes are
1. CommunityServer method `mail/messages/save` is
hidden and seems obsolete since
https://github.com/ONLYOFFICE/portals/commit/01407434c0bba0b7b6b2fa26d81da44999b96156